### PR TITLE
sprat-js needs a helper function for accessing hateoas constraints

### DIFF
--- a/src/main/resources/js/web.js
+++ b/src/main/resources/js/web.js
@@ -147,6 +147,25 @@ sprat.web = {
 			}
 
 			return [];
+		},
+		constraints: function(object, name) {
+			if (!object || !(object.constraints || object._constraints)) {
+				throw "Invalid HATEOAS object without .constraints";
+			}
+
+			var constraints = object._constraints || object.constraints;
+
+			if (constraints) {
+				var constraint = constraints[name];
+
+				if (!constraint) {
+					throw "HATEOAS constraint with name '" + name + "' does not exist";
+				}
+
+				return constraint;
+			}
+
+			return [];
 		}
 	},
 };

--- a/src/test/resources/js/web.tests.js
+++ b/src/test/resources/js/web.tests.js
@@ -102,7 +102,7 @@ describe("sprat.web.hateoas.embedded", function () {
 
 describe("sprat.web.hateoas.constraints", function () {
 
-    it("the constraint 'delete' can be found", function () {
+    it("the constraint 'delete' can be found in constraints", function () {
         var object = {
             constraints: {
                 delete: [
@@ -113,20 +113,56 @@ describe("sprat.web.hateoas.constraints", function () {
             }
         };
 
-        expect($hateoas.constraints(object, 'delete')[0]['id']).toEqual(111);
+        var actual = $hateoas.constraints(object, 'delete');
+        expect(actual.length).toEqual(1);
+        expect(actual[0]).toEqual({id: 111});
     });
 
-    it("the _constraints can be found", function () {
+    it("the constraint 'delete' can be found in _constraints", function () {
         var object = {
             _constraints: {
                 delete: [
                     {
                         id: 222
+                    },
+                    {
+                        id: 333
+                    },
+                    {
+                        id: 444
                     }
                 ]
             }
         };
 
-        expect($hateoas.constraints(object, 'delete')[0]['id']).toEqual(222);
+        var actual = $hateoas.constraints(object, 'delete');
+        expect(actual.length).toEqual(3);
+        expect(actual[0]).toEqual({id: 222});
+        expect(actual[1]).toEqual({id: 333});
+        expect(actual[2]).toEqual({id: 444});
+    });
+
+    it("an expection will be thrown because the object is invalid", function () {
+        var object = {};
+
+        expect(function () {
+            $hateoas.constraints(object, 'delete');
+        }).toThrow('Invalid HATEOAS object without .constraints');
+    });
+
+    it("an expection will be thrown because the constraint 'delete' does not exist", function () {
+        var object = {
+            constraints: {
+                somethingCompletelyDifferent: [
+                    {
+                        id: 111
+                    }
+                ]
+            }
+        };
+
+        expect(function () {
+            $hateoas.constraints(object, 'delete');
+        }).toThrow("HATEOAS constraint with name 'delete' does not exist");
     });
 });

--- a/src/test/resources/js/web.tests.js
+++ b/src/test/resources/js/web.tests.js
@@ -99,3 +99,34 @@ describe("sprat.web.hateoas.embedded", function () {
         expect($hateoas.embedded(object)).toEqual(object._embedded.customers);
     });
 });
+
+describe("sprat.web.hateoas.constraints", function () {
+
+    it("the constraint 'delete' can be found", function () {
+        var object = {
+            constraints: {
+                delete: [
+                    {
+                        id: 111
+                    }
+                ]
+            }
+        };
+
+        expect($hateoas.constraints(object, 'delete')[0]['id']).toEqual(111);
+    });
+
+    it("the _constraints can be found", function () {
+        var object = {
+            _constraints: {
+                delete: [
+                    {
+                        id: 222
+                    }
+                ]
+            }
+        };
+
+        expect($hateoas.constraints(object, 'delete')[0]['id']).toEqual(222);
+    });
+});


### PR DESCRIPTION
I want to access a constraint from a hateoas object like this:

`var o = {  
   "_constraints":{  
      "delete":[  
         {  
            "message":"Der Stundeneintrag kann nicht geändert werden, weil die Stunden bereits geprüft worden sind",
            "key":"already_checked",
            "field":null
         }
      ]
   }
};`

`$hateoas.constraints(o, 'delete');`
